### PR TITLE
slight refactor

### DIFF
--- a/dedup.py
+++ b/dedup.py
@@ -7,10 +7,13 @@ from lib import parse_sam, umi_data, naive_estimate
 parser = argparse.ArgumentParser(description = 'Read a coordinate-sorted SAM file with labeled UMIs and mark or remove duplicates due to PCR or optical cloning, but not duplicates present in the original library. When PCR/optical duplicates are detected, the reads with the highest total base qualities are marked as non-duplicate - note we do not discriminate on MAPQ, or other alignment features, because this would bias against polymorphisms.')
 parser.add_argument('-r', '--remove', action = 'store_true', help = 'remove PCR/optical duplicates instead of marking them')
 #parser.add_argument('-d', '--dist', action = 'store', help = 'maximum pixel distance for optical duplicates (Euclidean); set to 0 to skip optical duplicate detection', type = int, default = 100)
-parser.add_argument('infile', action = 'store') # actually this filename should be required since we can't use a stream
+parser.add_argument('-u', '--umi_table', action = 'store', help = 'table of UMI sequences and prior frequencies')
+parser.add_argument('infile', action = 'store', nargs = '?', default = '-') # actually this filename should be required since we can't use a stream
 parser.add_argument('outfile', action = 'store', nargs = '?', default = '-')
 args = parser.parse_args()
 # maybe should have some options about the output format
+if args.umi_table is None and args.infile == '-':
+	raise RuntimeError('cannot read from stream unless UMI table is provided')
 
 in_sam = pysam.Samfile(args.infile, 'rb')
 if in_sam.header['HD'].get('SO') != 'coordinate': raise RuntimeError('input file must be sorted by coordinate')
@@ -22,6 +25,7 @@ central concept: cheat a little, detecting duplicate reads by the fact that they
 implementation: as you traverse the coordinate-sorted input reads, add each read to both a FIFO buffer (so they can be output in the same order) and a dictionary that groups reads by start position and strand (which is what you need for deduplication); this is not inefficient because both data structures contain pointers to the same pysam.AlignedSegment objects
 then, after each input read, check the left end of the buffer to tell whether the oldest read is in a position that will never accumulate any more hits (because the input is sorted by coordinate); if so, estimate the duplication at that position, mark all the reads there accordingly, then output the read with the appropriate marking
 '''
+
 
 read_buffer = collections.deque()
 pos_tracker = ({}, {}) # data structure containing observed UMIs and corresponding tracking information; top level is by strand (0 = forward, 1 = reverse), then next level is by 5' read start position (dict since these will be sparse and are only looked up by identity), then at each position the next level is by UMI (dict), and that contains a variety of data; there is no level for reference ID because there is no reason to store more than one chromosome at a time
@@ -35,10 +39,10 @@ def pop_buffer(): # pop the oldest read off the buffer (into the output), but fi
 		
 		umi_counts = umi_data.make_umi_counts(umi_totals.keys(), (len(this_pos['reads'][umi]) if umi in this_pos['reads'] else 0 for umi in umi_totals.keys()))
 		
-		# P ESTIMATION GOES HERE
-		p_estimate = naive_estimate.estimate_p(umi_counts)
+		# P ESTIMATION / DEDUPLICATION GOES HERE
+		dedup_counts = naive_estimate.deduplicate_counts(umi_counts)
 		
-		umi_data.deduplicate(this_pos['reads'], p_estimate)
+		umi_data.mark_duplicates(this_pos['reads'], dedup_counts)
 		this_pos['deduplicated'] = True
 	
 	# output read
@@ -49,27 +53,15 @@ def pop_buffer(): # pop the oldest read off the buffer (into the output), but fi
 	if read is this_pos['last read']: del pos_tracker[read.is_reverse][start_pos]
 
 
-# first pass through the input: get total UMI counts
-umi_totals = None
-umi_length = 0
-for read in in_sam:
-	if parse_sam.is_good(read):
-		read_counter['read'] += 1
-		umi = parse_sam.get_umi(read)
-		if not umi_length:
-			umi_length = len(umi)
-			umi_totals = umi_data.make_umi_counts(umi_data.make_umi_list(umi_length))
-		elif len(umi) != umi_length:
-			raise RuntimeError('different UMI length in read ' + read.query_name)
-		umi_totals[umi] += 1
-in_sam.reset()
-sys.stderr.write('%i\tusable alignments read\n' % read_counter['read'])
+# first pass through the input: get total UMI counts (or use table instead, if provided)
+umi_totals = umi_data.read_umi_counts_from_sam(in_sam) if args.umi_table is None else umi_data.read_umi_counts_from_table(open(args.umi_table))
+if args.umi_table is None: sys.stderr.write('%i\tusable alignments read\n' % sum(umi_totals.values()))
 
 
 # second pass through the input
 for read in in_sam:
 	if not parse_sam.is_good(read):	continue
-	read_counter['reread'] += 1
+	read_counter['read'] += 1
 	
 	start_pos, umi = parse_sam.get_start_pos(read), parse_sam.get_umi(read)
 	
@@ -90,8 +82,9 @@ for read in in_sam:
 # flush the buffer
 while read_buffer: pop_buffer()
 
-assert(read_counter['reread'] == read_counter['read'])
+
 # generate summary statistics
-#sys.stderr.write('%i\tunduplicated\n%i\tlibrary duplicates\n%i\tPCR duplicates\n%i\toptical duplicates\n' % (read_counter['unduplicated'], read_counter['library duplicate'], read_counter['PCR duplicate'], read_counter['optical duplicate']))
+if args.umi_table is None: assert sum(umi_totals.values()) == read_counter['read']
+if args.umi_table is not None: sys.stderr.write('%i\tusable alignments read\n' % read_counter['read'])
 sys.stderr.write('%i\tunduplicated\n%i\tduplicates\n' % (read_counter['nonduplicate'], read_counter['duplicate']))
 

--- a/lib/naive_estimate.py
+++ b/lib/naive_estimate.py
@@ -5,3 +5,8 @@ def estimate_p (umi_counts):
 	n_umi = sum(count > 0 for count in umi_counts.values())
 	return n_umi / n_hit
 
+def deduplicate_counts (umi_counts):
+	for key in umi_counts:
+		if umi_counts[key] > 0: umi_counts[key] = 1
+	return umi_counts
+

--- a/lib/read_buffer.py
+++ b/lib/read_buffer.py
@@ -1,9 +1,0 @@
-import collections
-from . import parse_sam
-
-class ReadBuffer(collections.deque()):
-	'''
-	Queue of SAM reads grouped by start (5') position. Expects to have reads added in order of leftmost position (standard SAM sorting) and produces them in the same order. This allows collecting reads by start position without breaking the sort order.
-	'''
-	def popleft():
-		

--- a/lib/umi_data.py
+++ b/lib/umi_data.py
@@ -10,19 +10,41 @@ def make_umi_counts (umi_list, counts = None):
 	else:
 		return collections.OrderedDict((umi, 0) for umi in umi_list)
 
-def deduplicate (reads, p): # assumes 'reads' is a dict where each key is a UMI and each value is a list of pysam.AlignedSegment objects, all marked as is_duplicate = False
-	n_hit = sum(len(umi_hits) for umi_hits in reads.values())
-	assert p >= len(reads) / n_hit
-	
-	n_dup = round(n_hit * (1 - p))
-	
-	# this is stupid; an ideal solution would try to keep the number of retained reads from each UMI roughly proportional to how many hits it had, except always at least 1 for every UMI that had a nonzero count, and prioritize the best reads (longest with highest total score)
-	for umi_reads in reads.values():
-		try:
-			for read in umi_reads:
-				if n_dup == 0: raise StopIteration
-				read.is_duplicate = True
-				n_dup -= 1
-		except StopIteration:
-			break
+def read_umi_counts_from_table (infile):
+	result = collections.OrderedDict()
+	for line in infile:
+		split_line = line.split()
+		if len(split_line) >= 2: result[split_line[0]] = int(split_line[1])
+	if len(result) == 0: raise RuntimeError('bad format in UMI table')
+	return result
+
+def read_umi_counts_from_sam (infile):
+	umi_totals = None
+	umi_length = 0
+	file_pos = infile.tell() # save position so we can return there afterward
+	infile.reset()
+	for read in infile:
+		umi = parse_sam.get_umi(read)
+		if not umi_length:
+			umi_length = len(umi)
+			umi_totals = make_umi_counts(make_umi_list(umi_length))
+		elif len(umi) != umi_length:
+			raise RuntimeError('different UMI length in read ' + read.query_name)
+		if umi in umi_totals: umi_totals[umi] += 1 # exclude bad UMIs (containing N)
+	infile.seek(file_pos)
+	return umi_totals
+
+def mark_duplicates (reads, target_umi_counts):
+	'''
+	assumes 'reads' is a dict where each key is a UMI and each value is a list of pysam.AlignedSegment objects (pointers), all marked as is_duplicate = False
+	assumes 'target_umi_counts' is a dict where each key is a UMI and each value is the number of non-duplicate reads
+	so if len(reads[umi]) == 5 and target_umi_counts[umi] == 3, two reads from this UMI will be marked as duplicates
+	reads to mark as the duplicates are chosen by lowest base quality
+	'''
+	for umi in reads.keys():
+		assert len(reads[umi]) >= target_umi_counts[umi]
+		if len(reads[umi]) > target_umi_counts[umi]:
+			sorted_reads = sorted(reads[umi], key = parse_sam.get_quality)
+			for i in range(len(reads[umi]) - target_umi_counts[umi]):
+				sorted_reads[i].is_duplicate = True
 


### PR DESCRIPTION
dedup.py can now take a --umi_table argument to read prior frequencies (and the UMI list, if you don't just want all possible sequences of a fixed length) from a plaintext file; then it is not necessary to read them from the input SAM file, which means it can be a stream since it doesn't need to rewind

naive_estimate.estimate_p is replaced with naive_estimate.deduplicate_counts, which returns a vector of the deduplicated UMI hit counts instead of just the proportion of them that aren't duplicates

umi_data.deduplicate is replaced with umi_data.mark_duplicates, which takes the output of naive_estimate.deduplicate_counts (or equivalent) and marks duplicates accordingly, selectively retaining the highest-quality reads

functions for reading UMI hit totals from either the input SAM file or a table are moved to umi_data.py for use in other scripts (like one to generate the table in the first place)