### PR TITLE
Devel

### DIFF
--- a/dedup.py
+++ b/dedup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import collections, argparse, pysam, sys
-from lib import parse_sam, umi_data, optical_duplicates, naive_estimate
+from lib import parse_sam, umi_data, optical_duplicates, naive_estimate, uniform_estimate
 
 # parse arguments
 parser = argparse.ArgumentParser(description = 'Read a coordinate-sorted BAM file with labeled UMIs and mark or remove duplicates due to PCR or optical cloning, but not duplicates present in the original library. When PCR/optical duplicates are detected, the reads with the highest total base qualities are marked as non-duplicate - note we do not discriminate on MAPQ, or other alignment features, because this would bias against polymorphisms.')
@@ -11,6 +11,7 @@ parser_alg = parser.add_argument_group('algorithm')
 parser_perf = parser.add_argument_group('performance testing')
 parser_format.add_argument('-r', '--remove', action = 'store_true', help = 'remove PCR/optical duplicates instead of marking them')
 parser_alg.add_argument('-d', '--dist', action = 'store', type = int, default = 100, help = 'maximum pixel distance for optical duplicates (Euclidean); set to 0 to skip optical duplicate detection')
+parser_alg.add_argument('-a', '--algorithm', action = 'store', default = 'naive', help = 'algorithm for duplicate identification')
 parser_perf.add_argument('--truncate_umi', action = 'store', type = int, default = None, help = 'truncate UMI sequences to this length')
 parser_data.add_argument('in_file', action = 'store', nargs = '?', default = '-', help = 'input BAM')
 parser_data.add_argument('out_file', action = 'store', nargs = '?', default = '-', help = 'output BAM')
@@ -37,11 +38,11 @@ def pop_buffer(): # pop the oldest read off the buffer (into the output), but fi
 	read = read_buffer.popleft()
 	start_pos, umi = parse_sam.get_start_pos(read), umi_data.get_umi(read.query_name, args.truncate_umi)
 	this_pos = pos_tracker[read.is_reverse][start_pos]
-	
+
 	# deduplicate reads at this position
 	if not this_pos['deduplicated']:
 		umi_reads = this_pos['reads']
-		
+
 		# first pass: mark optical duplicates
 		if args.dist != 0:
 			all_reads = [] # combine reads from all UMIs so optical duplicates aren't required to have matching UMIs (maybe there was a sequencing error)
@@ -50,30 +51,30 @@ def pop_buffer(): # pop the oldest read off the buffer (into the output), but fi
 				for dup_read in umi_data.mark_duplicates(opt_dup, len(opt_dup) - 1):
 					if dup_read.is_duplicate: umi_reads[umi_data.get_umi(dup_read.query_name, args.truncate_umi)].remove(dup_read) # remove duplicate reads from the tracker so they won't be considered later (they're still in the read buffer)
 				read_counter['optical duplicate'] += len(opt_dup) - 1
-		
+
 		# second pass: mark PCR duplicates
 		umi_counts = umi_data.make_umi_counts(umi_totals.keys())
 		for umi, reads in umi_reads.items(): umi_counts[umi] = len(reads)
-		
+
 		# P ESTIMATION / DEDUPLICATION GOES HERE
-		# if args.algorithm == 'naive':
-	        dedup_counts = naive_estimate.deduplicate_counts(umi_counts)
-		
-		# if args.algorithm == 'uniform':
-		#     dedup_counts = uniform_estimate.deduplicate_counts(umi_counts)
+		if args.algorithm == 'naive':
+			dedup_counts = naive_estimate.deduplicate_counts(umi_counts)
+
+		if args.algorithm == 'uniform':
+		    dedup_counts = uniform_estimate.deduplicate_counts(umi_counts)
 
 		for umi, reads in umi_reads.items():
 			n_dup = len(reads) - dedup_counts[umi]
 			umi_data.mark_duplicates(reads, n_dup)
 			read_counter['PCR duplicate'] += n_dup
-		
+
 		read_counter['unique'] += sum(dedup_counts.values())
 
 		this_pos['deduplicated'] = True
-	
+
 	# output read
 	if not (args.remove and read.is_duplicate): out_bam.write(read)
-	
+
 	# prune the tracker
 	if read is this_pos['last read']: del pos_tracker[read.is_reverse][start_pos]
 
@@ -96,11 +97,11 @@ for read in in_bam:
 	read.is_duplicate = False # not sure how to handle reads that have already been deduplicated somehow, so just ignore previous annotations
 	start_pos = parse_sam.get_start_pos(read)
 	read_counter['read'] += 1
-	
+
 	# advance the buffer
 	while read_buffer and (read_buffer[0].reference_id < read.reference_id or parse_sam.get_start_pos(read_buffer[0]) < read.reference_start): pop_buffer() # pop the top read if it's at a position that's definitely not going to get any more hits
-	
-	# add read to buffer and tracking data structure	
+
+	# add read to buffer and tracking data structure
 	read_buffer.extend([read])
 	try:
 		pos_tracker[read.is_reverse][start_pos]['reads'][umi] += [read]

--- a/dedup.py
+++ b/dedup.py
@@ -56,11 +56,11 @@ def pop_buffer(): # pop the oldest read off the buffer (into the output), but fi
 		for umi, reads in umi_reads.items(): umi_counts[umi] = len(reads)
 		
 		# P ESTIMATION / DEDUPLICATION GOES HERE
-		if args.algorithm == 'naive':
-		    dedup_counts = naive_estimate.deduplicate_counts(umi_counts)
+		# if args.algorithm == 'naive':
+	        dedup_counts = naive_estimate.deduplicate_counts(umi_counts)
 		
-		if args.algorithm == 'uniform':
-		    dedup_counts = uniform_estimate.deduplicate_counts(umi_counts)
+		# if args.algorithm == 'uniform':
+		#     dedup_counts = uniform_estimate.deduplicate_counts(umi_counts)
 
 		for umi, reads in umi_reads.items():
 			n_dup = len(reads) - dedup_counts[umi]

--- a/lib/uniform_estimate.py
+++ b/lib/uniform_estimate.py
@@ -1,8 +1,6 @@
 from __future__ import division
 import numpy as np
-from scipy import stats
 import collections
-import random
 
 def deduplicate_counts (umi_counts, nsamp=1000, nthin=1, nburn=200):
 

--- a/lib/uniform_estimate.py
+++ b/lib/uniform_estimate.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy import stats
 import collections
 
-def estimate_p (umi_counts, nsamp=1000, nthin=1, nburn=200):
+def deduplicate_counts (umi_counts, nsamp=1000, nthin=1, nburn=200):
 
     n = len(umi_counts)
 
@@ -85,10 +85,3 @@ def estimate_p (umi_counts, nsamp=1000, nthin=1, nburn=200):
         umi_true[umi_counts.keys()[i]] = int(np.floor(median[i] * data[i]))
 
     return umi_true
-
-
-def deduplicate_counts (umi_counts):
-    for key in umi_counts:
-        if umi_counts[key] > 0: umi_counts[key] = 1
-    return umi_counts
-

--- a/lib/uniform_estimate.py
+++ b/lib/uniform_estimate.py
@@ -1,0 +1,94 @@
+from __future__ import division
+import numpy as np
+from scipy import stats
+import collections
+
+def estimate_p (umi_counts, nsamp=1000, nthin=1, nburn=200):
+
+    n = len(umi_counts)
+
+    # Create array containing data, to simplify computations
+    data = np.full((n,), 0)
+    for i in range(n):
+        data[i] = umi_counts.values()[i]
+
+    N = sum(data)
+    nits = nburn + nsamp * nthin
+    # The 'uniform' algorithm assumes equi-probability for all tags, before amplification
+    C_fixed = np.full((n,), 1./n)
+    # Results will be stored in a matrix
+    p_post = np.full((nsamp, n), 0)
+
+    # Set priors for the different parameters
+    pi_prior = np.array((1, 1))
+    S_prior = np.full((n, ), 1)
+
+    # Initialize random variables
+    pi_rv = stats.beta(pi_prior[0], pi_prior[1])
+    S_rv = stats.dirichlet(S_prior)
+    Y_rv = [0] * n
+    for i in range(n):
+        Y_rv[i] = stats.binom(data[i], 0.5)
+
+    # Starting values
+    pi_old = pi_rv.rvs(size = 1)
+    S_old = S_rv.rvs(size = 1)
+    Y_old = np.full((n,), 0)
+    Y_new = np.full((n,), 0)
+    for i in range(n):
+        Y_old[i] = Y_rv[i].rvs(size = 1)
+    p_old = ((pi_old * C_fixed) / (pi_old * C_fixed + (1 - pi_old) * S_old)).flatten()
+
+    index = 0
+    for i in range(nits):
+
+        #1. Update count of true molecules, using binomial distribution
+        for j in range(n):
+            Y_rv[j].args = (data[j], p_old[j])
+            Y_new[j] = Y_rv[j].rvs(size = 1)
+            # Accept-reject to stay in sample space
+            if Y_new[j] == 0 and data[j] >0:
+                Y_new[j] = Y_old[j]
+
+        Y = sum(Y_new)
+
+        #2. Update probability of being true molecule, using beta distribution
+        pi_rv.args = (Y + pi_prior[0], N - Y + pi_prior[1])
+        pi_new = pi_rv.rvs(size = 1)
+
+        #3. Update probability of having some tag given that it's a replicate, using dirichlet distribution
+        S_rv.args = data - Y_new + S_prior
+        S_new = S_rv.rvs(size = 1)
+
+        #4.  Probability of being true molecule given tag, using Bayes' theorem
+        p_new = ((pi_new * C_fixed) / (pi_new * C_fixed + (1 - pi_new) * S_new)).flatten()
+
+        # Should we record this draw?
+        if i >nburn and i % nthin == 0:
+            p_post[index,] = p_new
+            index += 1
+
+        # Re-initialize vectors before next draw
+        pi_old = pi_new
+        S_old = S_new
+        Y_old = Y_new
+        p_old = p_new
+
+    # Compute median for each tag
+    median = np.full((n,), 0)
+    for i in range(n):
+        median[i] = np.median(p_post[:,i])
+
+    # Return ordered dictionary with estimated number of true molecules
+    umi_true = collections.OrderedDict()
+    for i in range(n):
+        umi_true[umi_counts.keys()[i]] = int(np.floor(median[i] * data[i]))
+
+    return umi_true
+
+
+def deduplicate_counts (umi_counts):
+    for key in umi_counts:
+        if umi_counts[key] > 0: umi_counts[key] = 1
+    return umi_counts
+

--- a/lib/uniform_estimate.py
+++ b/lib/uniform_estimate.py
@@ -2,70 +2,62 @@ from __future__ import division
 import numpy as np
 from scipy import stats
 import collections
+import random
 
 def deduplicate_counts (umi_counts, nsamp=1000, nthin=1, nburn=200):
 
-    n = len(umi_counts)
+    data = umi_counts.values()
 
-    # Create array containing data, to simplify computations
-    data = np.full((n,), 0)
-    for i in range(n):
-        data[i] = umi_counts.values()[i]
-
+    n = len(data)
     N = sum(data)
     nits = nburn + nsamp * nthin
     # The 'uniform' algorithm assumes equi-probability for all tags, before amplification
-    C_fixed = np.full((n,), 1./n)
+    C_fixed = [1./n] * n
     # Results will be stored in a matrix
-    p_post = np.full((nsamp, n), 0)
+    p_post = [[0] * n] * nsamp
 
     # Set priors for the different parameters
-    pi_prior = np.array((1, 1))
-    S_prior = np.full((n, ), 1)
-
-    # Initialize random variables
-    pi_rv = stats.beta(pi_prior[0], pi_prior[1])
-    S_rv = stats.dirichlet(S_prior)
-    Y_rv = [0] * n
-    for i in range(n):
-        Y_rv[i] = stats.binom(data[i], 0.5)
+    pi_prior = [1, 1]
+    S_prior = [1] * n
 
     # Starting values
-    pi_old = pi_rv.rvs(size = 1)
-    S_old = S_rv.rvs(size = 1)
-    Y_old = np.full((n,), 0)
+    pi_old = np.random.beta(pi_prior[0], pi_prior[1])
+    S_alphas = S_prior
+    S_old = np.random.dirichlet(S_alphas)
+    Y_old = [0] * n
     Y_new = np.full((n,), 0)
+    p_old = [0] * n
+    p_new = [0] * n
+
+    # Start the algorithm
     for i in range(n):
-        Y_old[i] = Y_rv[i].rvs(size = 1)
-    p_old = ((pi_old * C_fixed) / (pi_old * C_fixed + (1 - pi_old) * S_old)).flatten()
+        Y_old[i] = np.random.binomial(data[i], 0.5)
+        p_old[i] = (pi_old * C_fixed[i]) / (pi_old * C_fixed[i] + (1 - pi_old) * S_old[i])
 
     index = 0
     for i in range(nits):
 
         #1. Update count of true molecules, using binomial distribution
         for j in range(n):
-            Y_rv[j].args = (data[j], p_old[j])
-            Y_new[j] = Y_rv[j].rvs(size = 1)
+            Y_new[j] = np.random.binomial(data[j], p_old[j])
             # Accept-reject to stay in sample space
             if Y_new[j] == 0 and data[j] >0:
                 Y_new[j] = Y_old[j]
-
-        Y = sum(Y_new)
+            S_alphas[j] = data[j] - Y_new[j] + S_prior[j]
 
         #2. Update probability of being true molecule, using beta distribution
-        pi_rv.args = (Y + pi_prior[0], N - Y + pi_prior[1])
-        pi_new = pi_rv.rvs(size = 1)
+        Y = sum(Y_new)
+        pi_new = np.random.beta(Y + pi_prior[0], N - Y + pi_prior[1])
 
         #3. Update probability of having some tag given that it's a replicate, using dirichlet distribution
-        S_rv.args = data - Y_new + S_prior
-        S_new = S_rv.rvs(size = 1)
+        S_new = np.random.dirichlet(S_alphas)
 
         #4.  Probability of being true molecule given tag, using Bayes' theorem
-        p_new = ((pi_new * C_fixed) / (pi_new * C_fixed + (1 - pi_new) * S_new)).flatten()
+        p_new = [(pi_new * C_fixed[j]) / (pi_new * C_fixed[j] + (1 - pi_new) * S_new[j]) for j in range(n)]
 
         # Should we record this draw?
         if i >nburn and i % nthin == 0:
-            p_post[index,] = p_new
+            p_post[index] = p_new
             index += 1
 
         # Re-initialize vectors before next draw
@@ -75,13 +67,35 @@ def deduplicate_counts (umi_counts, nsamp=1000, nthin=1, nburn=200):
         p_old = p_new
 
     # Compute median for each tag
-    median = np.full((n,), 0)
-    for i in range(n):
-        median[i] = np.median(p_post[:,i])
+    p_post_flat = [item for sublist in p_post for item in sublist]
 
-    # Return ordered dictionary with estimated number of true molecules
+    median_list = [0] * n
+
+    for i in range(n):
+        median_list[i] = computeMedian(p_post_flat[i::n])
+
+        # Return ordered dictionary with estimated number of true molecules
     umi_true = collections.OrderedDict()
     for i in range(n):
-        umi_true[umi_counts.keys()[i]] = int(np.ceiling(median[i] * data[i]))
+        umi_true[umi_counts.keys()[i]] = int(np.ceil(median_list[i] * data[i]))
 
     return umi_true
+
+def dirichletvariate(alphas):
+
+    sample = [random.gammavariate(alpha,1) for alpha in alphas]
+    sample = [x/sum(sample) for x in sample]
+
+    return sample
+
+def computeMedian(list):
+    list.sort()
+    lens = len(list)
+    if lens % 2 != 0:
+        midl = (lens / 2)
+        res = list[midl]
+    else:
+        odd = int((lens / 2) -1)
+        ev = int((lens / 2))
+        res = float(list[odd] + list[ev]) / float(2)
+    return res

--- a/lib/uniform_estimate.py
+++ b/lib/uniform_estimate.py
@@ -6,7 +6,11 @@ import random
 
 def deduplicate_counts (umi_counts, nsamp=1000, nthin=1, nburn=200):
 
-    data = umi_counts.values()
+    # Remove zeros from data, to shorten the vector
+    data = []
+    for value in umi_counts.values():
+        if value > 0:
+            data.append(value)
 
     n = len(data)
     N = sum(data)
@@ -74,10 +78,15 @@ def deduplicate_counts (umi_counts, nsamp=1000, nthin=1, nburn=200):
     for i in range(n):
         median_list[i] = computeMedian(p_post_flat[i::n])
 
-        # Return ordered dictionary with estimated number of true molecules
+    # Return ordered dictionary with estimated number of true molecules
     umi_true = collections.OrderedDict()
-    for i in range(n):
-        umi_true[umi_counts.keys()[i]] = int(np.ceil(median_list[i] * data[i]))
+    index = 0
+    for key, value in umi_counts.items():
+        if value == 0:
+            umi_true[key] = value
+        else:
+            umi_true[key] = int(np.ceil(median_list[index] * data[index]))
+            index += 1
 
     return umi_true
 

--- a/lib/uniform_estimate.py
+++ b/lib/uniform_estimate.py
@@ -82,6 +82,6 @@ def deduplicate_counts (umi_counts, nsamp=1000, nthin=1, nburn=200):
     # Return ordered dictionary with estimated number of true molecules
     umi_true = collections.OrderedDict()
     for i in range(n):
-        umi_true[umi_counts.keys()[i]] = int(np.floor(median[i] * data[i]))
+        umi_true[umi_counts.keys()[i]] = int(np.ceiling(median[i] * data[i]))
 
     return umi_true


### PR DESCRIPTION
We don't need to merge it right now, but I thought we could discuss the following points:

1. I'm using numpy.arrays as a convenience for myself, but since there is no complicated matrix operations we could easily change them to some other data type and remove that dependency.

2. To generate random variates, I use the scipy module. Because of the need for a Dirichlet random variable, I need a recent version (>= 0.15.0). If this is too strong a requirement, we could draw from gammas or betas, which are both part of any version of scipy.

3. As it is set-up right now, the MCMC algorithm is called using the default parameters (i.e. thining parameter, length of burn-in period and number of iterations are fixed). Perhaps we should add something to the parser to allow the user to change these parameters.

Let me know what you think.