### PR TITLE
new programs and code cleanup

### DIFF
--- a/extract_umi.py
+++ b/extract_umi.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import argparse, sys, collections, Bio.SeqIO
+
+parser = argparse.ArgumentParser(description = 'Read a FASTQ file containing UMIs prepended to alignable sequences, and output the same file with the UMIs moved into the read names. Report the base frequencies.')
+parser.add_argument('-b', '--before', action = 'store', type = int, default = 0, help = 'number of bases before UMI to discard')
+parser.add_argument('-a', '--after', action = 'store', type = int, default = 0, help = 'number of bases after UMI to discard')
+parser.add_argument('-m', '--mask', action = 'append', type = int, help = 'position within UMI to discard (can be used multiple times)')
+parser.add_argument('umi_length', action = 'store', type = int, help = 'length of UMI sequence (these bases become the UMI label)')
+parser.add_argument('in_file', action = 'store', nargs = '?', type = argparse.FileType('r'), default = sys.stdin)
+parser.add_argument('out_file', action = 'store', nargs = '?', type = argparse.FileType('w'), default = sys.stdout)
+args = parser.parse_args()
+
+read_counter = 0
+base_counter = [collections.Counter() for i in range(args.umi_length)]
+
+trim_length = args.before + args.umi_length + args.after
+try:
+	mask_pos = sorted(args.mask, reverse = True) # sorted in descending order so they can be done from the right end, i.e. each mask doesn't change the relative position of the next
+	if mask_pos[0] > args.umi_length: raise RuntimeError('UMI is only %i bases; can\'t mask position %i' % (args.umi_length, mask_pos[0]))
+except TypeError:
+	mask_pos = []
+
+for read in Bio.SeqIO.parse(args.in_file, 'fastq'):
+
+	if len(read.seq) <= trim_length: raise RuntimeError('%i bases to be trimmed but read %s is only %i bases' % (trim_length, read.id, len(read.seq)))
+	
+	# parse UMI
+	umi = str(read.seq[args.before:(args.before + args.umi_length)])
+	for i in range(args.umi_length): base_counter[i][umi[i]] += 1
+	
+	# mask UMI
+	for pos in mask_pos: umi = umi[:(pos - 1)] + umi[pos:]
+	
+	# modify read
+	read.id += ':' + umi
+	if ' ' in read.description: # problems with spaces
+		read.description = read.description[:read.description.index(' ')] + ':' + umi + read.description[read.description.index(' '):]
+	else:
+		read.description += ':' + umi
+	qualities = read.letter_annotations['phred_quality']
+	read.letter_annotations = {} # letter annotations must be emptied before changing sequence
+	
+	read.seq = read.seq[trim_length:]
+	read.letter_annotations['phred_quality'] = qualities[trim_length:]
+	
+	# output read
+	args.out_file.write(read.format('fastq'))
+	read_counter += 1
+
+
+# generate summary statistics
+sys.stderr.write('%i reads processed\n\n' % read_counter)
+
+alphabet = sorted(set.union(*(set(i) for i in base_counter))) # detect from data since it may include N
+sys.stderr.write('UMI base frequency by position\n')
+sys.stderr.write('\t'.join(alphabet) + '\n')
+for pos in base_counter:	sys.stderr.write('\t'.join(str(pos[base]) for base in alphabet) + '\n')
+sys.stderr.write('\n')
+

--- a/lib/parse_sam.py
+++ b/lib/parse_sam.py
@@ -1,12 +1,8 @@
 import collections
 
-def get_umi (read):
-	return read.query_name.partition(' ')[0].rpartition(':')[2]
-
-def is_good (read):
+def read_is_good (read):
 	if read.is_paired or read.is_read2: raise RuntimeError('paired-end reads are currently unsupported')
-	if read.query_name.count(':') != 7: raise RuntimeError('read name %s does not contain UMI in expected Casava 1.8+ / bcl2fastq 2.17+ format' % read.query_name)
-	return not (read.is_unmapped or read.is_secondary or read.is_supplementary or 'N' in get_umi(read)) # only count primary alignments, and discard unmapped reads since it's too expensive (and useless?) to find their duplicates; also discard reads with ambiguous UMIs
+	return not (read.is_unmapped or read.is_secondary or read.is_supplementary) # only count primary alignments, and discard unmapped reads since it's too expensive (and useless?) to find their duplicates
 
 def get_start_pos (read): # read start position in 0-based counting
 	return read.reference_end - 1 if read.is_reverse else read.reference_start

--- a/lib/umi_data.py
+++ b/lib/umi_data.py
@@ -1,37 +1,51 @@
 from __future__ import division
-import collections, itertools, parse_sam
+import collections, itertools, re, pysam, parse_sam
 
-def make_umi_list (length, alphabet = 'ACGT'):
+alphabet = 'ACGT'
+re_exclusion = re.compile('[^%s]' % alphabet)
+
+def make_umi_list (length, alphabet = alphabet):
 	return (''.join(umi) for umi in itertools.product(alphabet, repeat = length))
 
 def make_umi_counts (umi_list, counts = None):
-	if counts:
+	try:
 		return collections.OrderedDict((umi, count) for umi, count in zip(umi_list, counts))
-	else:
+	except TypeError:
 		return collections.OrderedDict((umi, 0) for umi in umi_list)
 
-def read_umi_counts_from_table (infile):
+def get_umi (read_name): # Illumina-specific
+	if read_name.count(':') != 7: raise RuntimeError('read name %s does not contain UMI in expected Casava 1.8+ / bcl2fastq 2.17+ format' % read_name)
+	return read_name.partition(' ')[0].rpartition(':')[2]
+
+def umi_is_good (umi):
+	return (len(umi) > 0 and re_exclusion.search(umi) is None)
+
+def read_umi_counts_from_table (in_file):
 	result = collections.OrderedDict()
-	for line in infile:
+	for line in in_file:
 		split_line = line.split()
 		if len(split_line) >= 2: result[split_line[0]] = int(split_line[1])
 	if len(result) == 0: raise RuntimeError('bad format in UMI table')
 	return result
 
-def read_umi_counts_from_sam (infile):
-	umi_totals = None
-	umi_length = 0
-	file_pos = infile.tell() # save position so we can return there afterward
-	infile.reset()
-	for read in infile:
-		umi = parse_sam.get_umi(read)
-		if not umi_length:
+def read_umi_counts_from_reads (in_file): # in_file should be a pysam.Samfile or a Bio.SeqIO.parse in 'fastq' format, or at least contain an Illumina-formatted name in either 'query_name' or 'id'
+	umi_totals, umi_length = None, None
+	for read in in_file:
+		try:
+			read_name = read.query_name
+		except AttributeError:
+			read_name = read.id # EAFP; if this isn't found either, AttributeError is still raised
+		umi = get_umi(read_name)
+		if umi_length is None:
 			umi_length = len(umi)
 			umi_totals = make_umi_counts(make_umi_list(umi_length))
 		elif len(umi) != umi_length:
-			raise RuntimeError('different UMI length in read ' + read.query_name)
-		if umi in umi_totals: umi_totals[umi] += 1 # exclude bad UMIs (containing N)
-	infile.seek(file_pos)
+			raise RuntimeError('different UMI length in read ' + read_name)
+		try:
+			umi_totals[umi] += 1
+		except KeyError:
+			pass # exclude bad UMIs
+	if umi_totals is None: raise RuntimeError('no valid reads detected')
 	return umi_totals
 
 def mark_duplicates (reads, target_umi_counts):

--- a/make_frequency_table.py
+++ b/make_frequency_table.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import collections, itertools, argparse, sys, Bio.SeqIO, pysam
+from lib import umi_data
+
+# parse arguments
+parser = argparse.ArgumentParser(description = 'Read a BAM or FASTQ file and generate a table containing the number of times each UMI was observed.')
+parser.add_argument('-f', '--fastq', action = 'store_true', help = 'input file is FASTQ format rather than BAM')
+parser.add_argument('in_file', action = 'store', nargs = '?', default = sys.stdin)
+parser.add_argument('out_file', action = 'store', nargs = '?', type = argparse.FileType('w'), default = sys.stdout)
+args = parser.parse_args()
+
+umi_totals = umi_data.read_umi_counts_from_reads(Bio.SeqIO.parse(args.in_file, 'fastq') if args.fastq else pysam.Samfile('-' if args.in_file is sys.stdin else args.in_file, 'rb'))
+
+# generate summary statistics
+sys.stderr.write('%i UMIs read\n' % sum(umi_totals.values()))
+for umi, count in umi_totals.items():
+	args.out_file.write('%s\t%i\n' % (umi, count))
+


### PR DESCRIPTION
extract_umi.py: take UMIs out of a FASTQ file's sequences and move them into the read names (required before alignment)

make_frequency_table.py: given either a FASTQ or BAM file, generate a table of UMI hit frequencies suitable as input for dedup.py

changed "SAM" to "BAM" where appropriate since only BAM input is supported

changed "infile" and "outfile" to "in_file" and "out_file" for more consistent variable naming

replaced lib/parse_sam.get_umi with lib/umi_data.get_umi, which takes just a read name instead of the whole read object, so that it works on either FASTQ or BAM

changed LBYL to EAFP for better pythonicity

moved UMI test out of lib/parse_sam.read_is_good into lib/umi_data.umi_is_good so it can be used on FASTQ UMIs too

changed lib/umi_data.read_umi_counts_from_sam to lib/umi_data.read_umi_counts_from_reads, which works on either FASTQ or BAM