### PR TITLE
UMI truncation and organized arguments

### DIFF
--- a/extract_umi.py
+++ b/extract_umi.py
@@ -2,13 +2,16 @@
 
 import argparse, sys, collections, Bio.SeqIO
 
+# parse arguments
 parser = argparse.ArgumentParser(description = 'Read a FASTQ file containing UMIs prepended to alignable sequences, and output the same file with the UMIs moved into the read names. Report the base frequencies.')
-parser.add_argument('-b', '--before', action = 'store', type = int, default = 0, help = 'number of bases before UMI to discard')
-parser.add_argument('-a', '--after', action = 'store', type = int, default = 0, help = 'number of bases after UMI to discard')
-parser.add_argument('-m', '--mask', action = 'append', type = int, help = 'position within UMI to discard (can be used multiple times)')
-parser.add_argument('umi_length', action = 'store', type = int, help = 'length of UMI sequence (these bases become the UMI label)')
-parser.add_argument('in_file', action = 'store', nargs = '?', type = argparse.FileType('r'), default = sys.stdin)
-parser.add_argument('out_file', action = 'store', nargs = '?', type = argparse.FileType('w'), default = sys.stdout)
+parser_data = parser.add_argument_group('data files')
+parser_umi = parser.add_argument_group('UMI format')
+parser_umi.add_argument('umi_length', action = 'store', type = int, help = 'length of UMI sequence (these bases become the UMI label)')
+parser_umi.add_argument('-b', '--before', action = 'store', type = int, default = 0, help = 'number of bases before UMI to discard')
+parser_umi.add_argument('-a', '--after', action = 'store', type = int, default = 0, help = 'number of bases after UMI to discard')
+parser_umi.add_argument('-m', '--mask', action = 'append', type = int, help = 'position within UMI to discard (can be used multiple times)')
+parser_data.add_argument('in_file', action = 'store', nargs = '?', type = argparse.FileType('r'), default = sys.stdin, help = 'input FASTQ')
+parser_data.add_argument('out_file', action = 'store', nargs = '?', type = argparse.FileType('w'), default = sys.stdout, help = 'output FASTQ')
 args = parser.parse_args()
 
 read_counter = 0

--- a/make_frequency_table.py
+++ b/make_frequency_table.py
@@ -5,12 +5,16 @@ from lib import umi_data
 
 # parse arguments
 parser = argparse.ArgumentParser(description = 'Read a BAM or FASTQ file and generate a table containing the number of times each UMI was observed.')
-parser.add_argument('-f', '--fastq', action = 'store_true', help = 'input file is FASTQ format rather than BAM')
-parser.add_argument('in_file', action = 'store', nargs = '?', default = sys.stdin)
-parser.add_argument('out_file', action = 'store', nargs = '?', type = argparse.FileType('w'), default = sys.stdout)
+parser_data = parser.add_argument_group('data files')
+parser_format = parser.add_argument_group('format')
+parser_perf = parser.add_argument_group('performance testing')
+parser_format.add_argument('-f', '--fastq', action = 'store_true', help = 'input file is FASTQ format rather than BAM')
+parser_perf.add_argument('--truncate_umi', action = 'store', type = int, default = None, help = 'truncate UMI sequences to this length')
+parser_data.add_argument('in_file', action = 'store', nargs = '?', default = sys.stdin, help = 'input BAM or FASTQ')
+parser_data.add_argument('out_file', action = 'store', nargs = '?', type = argparse.FileType('w'), default = sys.stdout, help = 'output table')
 args = parser.parse_args()
 
-umi_totals = umi_data.read_umi_counts_from_reads(Bio.SeqIO.parse(args.in_file, 'fastq') if args.fastq else pysam.Samfile('-' if args.in_file is sys.stdin else args.in_file, 'rb'))
+umi_totals = umi_data.read_umi_counts_from_reads((Bio.SeqIO.parse(args.in_file, 'fastq') if args.fastq else pysam.Samfile('-' if args.in_file is sys.stdin else args.in_file, 'rb')), args.truncate_umi)
 
 # generate summary statistics
 sys.stderr.write('%i UMIs read\n' % sum(umi_totals.values()))


### PR DESCRIPTION
UMI readers now allow truncating the sequences to their first few bases, for performance testing (how much worse would my results be if I only had 3 nt instead of 5?). Truncating to zero simulates the deduplication you would have if you weren't using UMIs at all (tentatively).

Command-line arguments are now organized into groups and ordered more logically.

The reading functions in lib/umi_data.py are now a little more pythonic and perhaps efficient.