### PR TITLE
New feat

### DIFF
--- a/extract_umi.py
+++ b/extract_umi.py
@@ -50,7 +50,8 @@ for read in Bio.SeqIO.parse(args.in_file, 'fastq'):
 	# output read
 	args.out_file.write(read.format('fastq'))
 	read_counter += 1
-
+args.in_file.close()
+args.out_file.close()
 
 # generate summary statistics
 sys.stderr.write('%i reads processed\n\n' % read_counter)

--- a/lib/optical_duplicates.py
+++ b/lib/optical_duplicates.py
@@ -1,17 +1,30 @@
 import collections, parse_sam
 	
 def are_optical_duplicates (coords1, coords2, max_dist):
-	return (coords1.tile == coords2.tile and (coords1.x - coords2.x) ** 2 + (coords1.y - coords2.y) ** 2 <= max_dist)
+	return (coords1.x - coords2.x) ** 2 + (coords1.y - coords2.y) ** 2 <= max_dist
 
 def get_optical_duplicates (reads, max_dist): # return a list where each element is a list of the reads that are optical duplicates of each other (each read is within max_dist of at least one other read in the set)
-	coords = map(parse_sam.get_coords, reads)
-	which_group = list(range(len(reads))) # directory of which group each read is in; initially each read is in its own group
-	groups = [[read] for read in reads] # list of all the groups
-	for i in range(len(reads) - 1):
-		for j in range(i + 1, len(reads)):
-			if are_optical_duplicates(coords[i], coords[j], max_dist):
-				groups[which_group[i]] += groups[which_group[j]] # move the second read's entire group into the first read's group
-				groups[which_group[j]] = [] # delete the second read's group so it won't be duplicated
-				which_group[j] = which_group[i] # point the second read to the first read's group
-	return [group for group in groups if len(group) > 1] # return only the groups with multiple elements
+	coords_by_tile = {} # group reads by which tile they came from; each value is another dictionary, in which the key is the coordinates and the value is the read itself
+	for read in reads:
+		coords = parse_sam.get_coords(read)
+		try:
+			coords_by_tile[coords.tile] += [(read, coords)]
+		except KeyError:
+			coords_by_tile[coords.tile] = [(read, coords)]
+	
+	result = [] # each element will be a list of reads that are optical duplicates of each other (within max_dist pixels)
+	for tile_reads in coords_by_tile.values():
+		if len(tile_reads) > 1:
+			which_group = list(range(len(tile_reads))) # directory of which group each read is in; initially each read is in its own group
+			groups = [[read[0]] for read in tile_reads] # list of all the groups
+			for i in range(len(tile_reads) - 1):
+				for j in range(i + 1, len(tile_reads)):
+					if are_optical_duplicates(tile_reads[i][1], tile_reads[j][1], max_dist):
+						groups[which_group[i]] += groups[which_group[j]] # move the second read's entire group into the first read's group
+						groups[which_group[j]] = [] # delete the second read's group so it won't be duplicated
+						which_group[j] = which_group[i] # point the second read to the first read's group
+			for group in groups:
+				if len(group) > 1: result += [group] # return only the groups with multiple elements
+
+	return result
 

--- a/make_frequency_table.py
+++ b/make_frequency_table.py
@@ -15,9 +15,11 @@ parser_data.add_argument('out_file', action = 'store', nargs = '?', type = argpa
 args = parser.parse_args()
 
 umi_totals = umi_data.read_umi_counts_from_reads((Bio.SeqIO.parse(args.in_file, 'fastq') if args.fastq else pysam.Samfile('-' if args.in_file is sys.stdin else args.in_file, 'rb')), args.truncate_umi)
+args.in_file.close()
 
 # generate summary statistics
 sys.stderr.write('%i UMIs read\n' % sum(umi_totals.values()))
 for umi, count in umi_totals.items():
 	args.out_file.write('%s\t%i\n' % (umi, count))
+args.out_file.close()
 


### PR DESCRIPTION
A rare but potentially fatal bug is fixed: the optical duplicate remove was changing which read was under consideration after popping it off the buffer, possibly resulting in premature deletion of its entry in the position tracker.

All reads at a given start position are now treated as potential optical duplicates, even if their UMIs don't match (there could have been a sequencing error).

The optical duplicate detection algorithm is now much more efficient: it groups reads by tile before doing the all-by-all comparison separately in each tile.

Open files are now explicitly closed, as soon as possible, since this was causing problems when streaming the output into another process (possibly this bug: http://bugs.python.org/issue11380).
