### PR TITLE
move deduplication buffer into library

### DIFF
--- a/dedup.py
+++ b/dedup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import copy, collections, argparse, pysam, sys
-from lib import parse_sam, umi_data, optical_duplicates, naive_estimate, bayes_estimate
+from lib import parse_sam, umi_data, optical_duplicates, naive_estimate, bayes_estimate, markdup_sam
 
 # parse arguments
 parser = argparse.ArgumentParser(description = 'Read a coordinate-sorted BAM file with labeled UMIs and mark or remove duplicates due to PCR or optical cloning, but not duplicates present in the original library. When PCR/optical duplicates are detected, the reads with the highest total base qualities are marked as non-duplicate - note we do not discriminate on MAPQ, or other alignment features, because this would bias against polymorphisms.')
@@ -10,7 +10,7 @@ parser_format = parser.add_argument_group('format')
 parser_alg = parser.add_argument_group('algorithm')
 parser_perf = parser.add_argument_group('performance testing')
 parser_format.add_argument('-r', '--remove', action = 'store_true', help = 'remove PCR/optical duplicates instead of marking them')
-parser_alg.add_argument('-d', '--dist', action = 'store', type = int, default = 100, help = 'maximum pixel distance for optical duplicates (Euclidean); set to 0 to skip optical duplicate detection')
+parser_alg.add_argument('-d', '--dist', action = 'store', type = int, default = optical_duplicates.DEFAULT_DIST, help = 'maximum pixel distance for optical duplicates (Euclidean); set to 0 to skip optical duplicate detection')
 parser_alg.add_argument('-a', '--algorithm', action = 'store', default = 'naive', choices = ['naive', 'bayes', 'uniform-bayes'], help = 'algorithm for duplicate identification')
 parser_alg.add_argument('--nsamp', action = 'store', type = int, default = bayes_estimate.DEFAULT_NSAMP)
 parser_alg.add_argument('--nthin', action = 'store', type = int, default = bayes_estimate.DEFAULT_NTHIN)
@@ -27,70 +27,6 @@ if args.algorithm == 'bayes' and args.umi_table is None and args.in_file == '-':
 in_bam = pysam.Samfile(args.in_file, 'rb')
 if in_bam.header['HD'].get('SO') != 'coordinate': raise RuntimeError('input file must be sorted by coordinate')
 out_bam = pysam.Samfile(args.out_file, 'wb', template = in_bam) # should add a line to the header indicating it was processed
-read_counter = collections.Counter()
-
-'''
-central concept: cheat a little, detecting duplicate reads by the fact that they align to the same (start) position rather than by their sequences
-implementation: as you traverse the coordinate-sorted input reads, add each read to both a FIFO buffer (so they can be output in the same order) and a dictionary that groups reads by start position and strand (which is what you need for deduplication); this is not inefficient because both data structures contain pointers to the same pysam.AlignedSegment objects
-then, after each input read, check the left end of the buffer to tell whether the oldest read is in a position that will never accumulate any more hits (because the input is sorted by coordinate); if so, estimate the duplication at that position, mark all the reads there accordingly, then output the read with the appropriate marking
-'''
-
-
-read_buffer = collections.deque()
-pos_tracker = ({}, {}) # data structure containing observed UMIs and corresponding tracking information; top level is by strand (0 = forward, 1 = reverse), then next level is by 5' read start position (dict since these will be sparse and are only looked up by identity), then at each position the next level is by UMI (dict), and that contains a variety of data; there is no level for reference ID because there is no reason to store more than one chromosome at a time
-def pop_buffer(): # pop the oldest read off the buffer (into the output), but first make sure its position has been deduplicated
-	read = read_buffer.popleft()
-	start_pos, umi = parse_sam.get_start_pos(read), umi_data.get_umi(read.query_name, args.truncate_umi)
-	this_pos = pos_tracker[read.is_reverse][start_pos]
-
-	# deduplicate reads at this position
-	if not this_pos['deduplicated']:
-		umi_reads = this_pos['reads']
-
-		# first pass: mark optical duplicates
-		if args.dist != 0:
-			all_reads = [] # combine reads from all UMIs so optical duplicates aren't required to have matching UMIs (maybe there was a sequencing error)
-			for reads in umi_reads.values(): all_reads += reads
-			for opt_dup in optical_duplicates.get_optical_duplicates(all_reads, args.dist):
-				for dup_read in umi_data.mark_duplicates(opt_dup, len(opt_dup) - 1):
-					# remove duplicate reads from the tracker so they won't be considered later (they're still in the read buffer)
-					if dup_read.is_duplicate:
-						umi = umi_data.get_umi(dup_read.query_name, args.truncate_umi)
-						umi_reads[umi].remove(dup_read)
-						if not umi_reads[umi]: del umi_reads[umi]
-				read_counter['optical duplicate'] += len(opt_dup) - 1
-
-		# second pass: mark PCR duplicates
-		umi_counts = umi_data.make_umi_counts(umi_reads.keys(), map(len, umi_reads.values()))
-
-		if args.algorithm == 'naive':
-			dedup_counts = naive_estimate.deduplicate_counts(umi_counts)
-		elif args.algorithm == 'uniform-bayes':
-			dedup_counts = bayes_estimate.deduplicate_counts(umi_counts, args.nsamp, args.nthin, args.nburn, True)
-		elif args.algorithm == 'bayes':
-			dedup_counts = bayes_estimate.deduplicate_counts(umi_counts, args.nsamp, args.nthin, args.nburn, False)
-		else:
-			raise NotImplementedError
-
-		for umi, reads in umi_reads.items(): # only UMIs with nonzero counts
-			assert reads
-			dedup_count = dedup_counts[umi]
-			n_dup = len(reads) - dedup_count
-			umi_data.mark_duplicates(reads, n_dup)
-			read_counter['PCR duplicate'] += n_dup
-			read_counter['UMI rescued'] += 1
-			read_counter['algorithm rescued'] += dedup_count - 1
-		read_counter['UMI rescued'] -= 1 # count the first read at this position as 'distinct'
-		read_counter['distinct'] += 1
-
-		this_pos['deduplicated'] = True
-
-	# output read
-	if not (args.remove and read.is_duplicate): out_bam.write(read)
-
-	# prune the tracker
-	if read is this_pos['last read']: del pos_tracker[read.is_reverse][start_pos]
-
 
 # first pass through the input: get total UMI counts (or use table instead, if provided)
 try:
@@ -101,41 +37,30 @@ except TypeError:
 		umi_totals = umi_data.read_umi_counts_from_reads(in_bam, args.truncate_umi)
 		sys.stderr.write('%i\tusable alignments read\n' % sum(umi_totals.values()))
 		in_bam.reset()
+	else:
+		umi_totals = None
 
-
-# second pass through the input
-for read in in_bam:
-	if not parse_sam.read_is_good(read): continue
-	umi = umi_data.get_umi(read.query_name, args.truncate_umi)
-	if not umi_data.umi_is_good(umi): continue
-	read.is_duplicate = False # not sure how to handle reads that have already been deduplicated somehow, so just ignore previous annotations
-	start_pos = parse_sam.get_start_pos(read)
-	read_counter['read'] += 1
-
-	# advance the buffer
-	while read_buffer and (read_buffer[0].reference_id < read.reference_id or parse_sam.get_start_pos(read_buffer[0]) < read.reference_start): pop_buffer() # pop the top read if it's at a position that's definitely not going to get any more hits
-
-	# add read to buffer and tracking data structure
-	read_buffer.extend([read])
-	try:
-		pos_tracker[read.is_reverse][start_pos]['reads'][umi] += [read]
-	except KeyError: # first time we've seen this UMI at this position+strand
-		try:
-			pos_tracker[read.is_reverse][start_pos]['reads'][umi] = [read]
-		except KeyError: # first time we've since this position+strand
-			pos_tracker[read.is_reverse][start_pos] = {'reads': {umi: [read]}, 'deduplicated': False}
-	pos_tracker[read.is_reverse][start_pos]['last read'] = read
+# second pass: mark duplicates
+dup_marker = markdup_sam.DuplicateMarker(
+	alignments = in_bam,
+	umi_frequency = umi_totals,
+	algorithm = args.algorithm,
+	optical_dist = args.dist,
+	truncate_umi = args.truncate_umi,
+	nsamp = args.nsamp,
+	nthin = args.nthin,
+	nburn = args.nburn
+)
+for alignment in dup_marker:
+	if not (args.remove and alignment.is_duplicate): out_bam.write(alignment)
 in_bam.close()
-
-# flush the buffer
-while read_buffer: pop_buffer()
 out_bam.close()
 
-# generate summary statistics
+# report summary statistics
 if args.algorithm == 'bayes' and args.umi_table is None:
-	assert sum(umi_totals.values()) == read_counter['read']
+	assert sum(umi_totals.values()) == dup_marker.counts['usable alignment']
 else:
-	sys.stderr.write('%i\tusable alignments read\n' % read_counter['read'])
-if args.dist != 0: sys.stderr.write('%i\toptical duplicates\n' % read_counter['optical duplicate'])
-sys.stderr.write('%i\tPCR duplicates\n%i\tdistinct alignments\n%i\tpre-PCR duplicates rescued by UMIs\n%i\tpre-PCR duplicates rescued by algorithm\n' % tuple(read_counter[x] for x in ['PCR duplicate', 'distinct', 'UMI rescued', 'algorithm rescued']))
+	sys.stderr.write('%i\talignments read\n%i\tusable alignments read\n' % (dup_marker.counts['alignment'], dup_marker.counts['usable alignment']))
+if args.dist != 0: sys.stderr.write('%i\toptical duplicates\n' % dup_marker.counts['optical duplicate'])
+sys.stderr.write('%i\tPCR duplicates\n%i\tdistinct alignments\n%i\tpre-PCR duplicates rescued by UMIs\n%i\tpre-PCR duplicates rescued by algorithm\n' % tuple(dup_marker.counts[x] for x in ['PCR duplicate', 'distinct', 'UMI rescued', 'algorithm rescued']))
 

--- a/lib/markdup_sam.py
+++ b/lib/markdup_sam.py
@@ -1,0 +1,121 @@
+import collections, parse_sam, umi_data, optical_duplicates, naive_estimate, bayes_estimate
+
+class DuplicateMarker:
+	'''
+	a generator of duplicate-marked alignments (like pysam.AlignedSegment objects), given an iterable of alignments (like a pysam.AlignmentFile) as input
+	assumes the input iterable is sorted by leftmost coordinate (SAMtools style) and yields alignments in the same order
+	does not yield unusable alignments
+	central concept: cheat a little, detecting duplicate reads by the fact that they align to the same (start) position rather than by their sequences
+	implementation: as you traverse the coordinate-sorted input reads, add each read to both a FIFO buffer (so they can be output in the same order) and a dictionary that groups reads by start position and strand (which is what you need for deduplication); this is not inefficient because both data structures contain pointers to the same alignment objects
+	then, after each input read, check the left end of the buffer to tell whether the oldest read is in a position that will never accumulate any more hits (because the input is sorted by coordinate); if so, estimate the duplication at that position, mark all the reads there accordingly, then output the read with the appropriate marking
+	'''
+	def __init__(self, 
+		alignments,
+		umi_frequency = None,
+		algorithm = 'bayes',
+		optical_dist = optical_duplicates.DEFAULT_DIST,
+		truncate_umi = None,
+		nsamp = bayes_estimate.DEFAULT_NSAMP,
+		nthin = bayes_estimate.DEFAULT_NTHIN,
+		nburn = bayes_estimate.DEFAULT_NBURN
+	):
+		self.alignments = alignments
+		self.umi_frequency = umi_frequency
+		self.optical_dist = optical_dist
+		self.truncate_umi = truncate_umi
+		if algorithm == 'naive':
+			self.umi_dup_function = naive_estimate.deduplicate_counts
+		elif algorithm in ('bayes', 'uniform-bayes'):
+			self.umi_dup_function = lambda counts: bayes_estimate.deduplicate_counts(umi_counts = counts, nsamp = nsamp, nthin = nthin, nburn = nburn, uniform = (algorithm == 'uniform-bayes'))
+		else:
+			raise NotImplementedError
+		self.alignment_buffer = collections.deque()
+		self.pos_tracker = ({}, {}) # data structure containing alignments by position rather than sort order; top level is by strand (0 = forward, 1 = reverse), then next level is by 5' read start position (dict since these will be sparse and are only looked up by identity), and that contains a variety of data; there is no level for reference ID because there is no reason to store more than one chromosome at a time
+		self.counts = collections.Counter()
+		self.output_generator = self.get_marked_alignment()
+	
+	def __iter__(self):
+		return self
+	
+	def __next__(self):
+		return next(self.output_generator)
+	
+	def iter(self):
+		return self
+	
+	def next(self):
+		return next(self.output_generator)
+	
+	def pop_buffer(self):
+		alignment = self.alignment_buffer.popleft()
+		start_pos = parse_sam.get_start_pos(alignment)
+		pos_data = self.pos_tracker[alignment.is_reverse][start_pos]
+		
+		# deduplicate reads
+		if not pos_data['deduplicated']:
+			alignments = pos_data['alignments']
+			
+			# first pass: mark optical duplicates
+			if self.optical_dist != 0:
+				for opt_dups in optical_duplicates.get_optical_duplicates(alignments, self.optical_dist):
+					for alignment in umi_data.mark_duplicates(opt_dups, len(opt_dups) - 1):
+						# remove duplicate reads from the tracker so they won't be considered later (they're still in the read buffer)
+						if alignment.is_duplicate: alignments.remove(alignment)
+					self.counts['optical duplicate'] += len(opt_dups) - 1
+			
+			# second pass: mark PCR duplicates
+			alignments_by_umi = collections.defaultdict(list)
+			for this_alignment in alignments: alignments_by_umi[umi_data.get_umi(this_alignment.query_name, self.truncate_umi)] += [this_alignment]
+			dedup_counts = self.umi_dup_function(umi_data.make_umi_counts(alignments_by_umi.keys(), map(len, alignments_by_umi.values())))
+			for umi, alignments, dedup_count in zip(alignments_by_umi.keys(), alignments_by_umi.values(), dedup_counts.values()):
+				assert alignments
+				n_dup = len(alignments) - dedup_count
+				umi_data.mark_duplicates(alignments, n_dup)
+				self.counts['PCR duplicate'] += n_dup
+				self.counts['UMI rescued'] += 1
+				self.counts['algorithm rescued'] += dedup_count - 1
+			self.counts['UMI rescued'] -= 1 # count the first read at this position as distinct
+			self.counts['distinct'] += 1
+			
+			pos_data['deduplicated'] = True
+		
+		# garbage collection
+		if alignment is pos_data['last alignment']: del self.pos_tracker[alignment.is_reverse][start_pos]
+		
+		return alignment
+	
+	def get_marked_alignment(self):
+		for alignment in self.alignments:
+			self.counts['alignment'] += 1
+			if not ( # verify sorting
+				(not self.alignment_buffer) or (
+					alignment.reference_id > self.alignment_buffer[-1].reference_id or (
+						alignment.reference_id == self.alignment_buffer[-1].reference_id and
+						alignment.reference_start >= self.alignment_buffer[-1].reference_start
+					)
+				)
+			): raise RuntimeError('alignment %s out of order: verify sorting' % alignment.query_name)
+			if not parse_sam.alignment_is_good(alignment): continue
+			umi = umi_data.get_umi(alignment.query_name, self.truncate_umi)
+			if not umi_data.umi_is_good(umi): continue
+			alignment.is_duplicate = False # not sure how to handle alignments that have already been deduplicated somehow, so just ignore previous annotations
+			start_pos = parse_sam.get_start_pos(alignment)
+			self.counts['usable alignment'] += 1
+			
+			# advance the buffer
+			while self.alignment_buffer and (
+				self.alignment_buffer[0].reference_id < alignment.reference_id or # new chromosome
+				parse_sam.get_start_pos(self.alignment_buffer[0]) < alignment.reference_start # oldest buffer member is now guaranteed not to get any more hits at its position
+			): yield self.pop_buffer()
+			
+			# add the alignment to the tracking data structures
+			self.alignment_buffer.extend([alignment])
+			try:
+				self.pos_tracker[alignment.is_reverse][start_pos]['alignments'] += [alignment]
+			except KeyError: # first time we've seen this position+strand
+				self.pos_tracker[alignment.is_reverse][start_pos] = {'alignments': [alignment], 'deduplicated': False}
+			self.pos_tracker[alignment.is_reverse][start_pos]['last alignment'] = alignment
+		
+		# flush the buffer
+		while self.alignment_buffer: yield self.pop_buffer()
+

--- a/lib/optical_duplicates.py
+++ b/lib/optical_duplicates.py
@@ -1,5 +1,7 @@
 import collections, parse_sam
-	
+
+DEFAULT_DIST = 100
+
 def are_optical_duplicates (coords1, coords2, max_dist):
 	return (coords1.x - coords2.x) ** 2 + (coords1.y - coords2.y) ** 2 <= max_dist
 

--- a/lib/parse_sam.py
+++ b/lib/parse_sam.py
@@ -1,18 +1,18 @@
 import collections
 
-def read_is_good (read):
-	if read.is_paired or read.is_read2: raise RuntimeError('paired-end reads are currently unsupported')
-	return not (read.is_unmapped or read.is_secondary or read.is_supplementary) # only count primary alignments, and discard unmapped reads since it's too expensive (and useless?) to find their duplicates
+def alignment_is_good (alignment):
+	if alignment.is_paired or alignment.is_read2: raise RuntimeError('paired-end reads are currently unsupported')
+	return not (alignment.is_unmapped or alignment.is_secondary or alignment.is_supplementary) # only count primary alignments, and discard unmapped reads since it's too expensive (and useless?) to find their duplicates
 
-def get_start_pos (read): # read start position in 0-based counting
-	return read.reference_end - 1 if read.is_reverse else read.reference_start
+def get_start_pos (alignment): # alignment start position in 0-based counting
+	return alignment.reference_end - 1 if alignment.is_reverse else alignment.reference_start
 
-def get_quality (read):
-	return sum(read.query_qualities)
+def get_quality (alignment):
+	return sum(alignment.query_qualities)
 
 Coords = collections.namedtuple('Coords', ['tile', 'x', 'y']) # "tile" actually also contains machine name, flow cell name, lane, etc. - enough to specify this tile all in one unique string
 
-def get_coords (read):
-	tile, x_string, y_string = read.query_name.rsplit(':', 3)[:3]
+def get_coords (alignment):
+	tile, x_string, y_string = alignment.query_name.rsplit(':', 3)[:3]
 	return Coords(tile, int(x_string), int(y_string))
 


### PR DESCRIPTION
The complicated system of buffers and trackers that was previously in dedup.py is now abstracted into a generator class in lib/markdup_sam.py. This makes the software more suitable to become a Python module, not just a set of standalone programs. It it also a step toward a parallelization scheme I'm still working on.

Note that the deduplication library is now invoked in `lib/markdup.py:29`. The total UMI counts are available as `self.umi_frequency` and can be added as an argument there. This variable may be `None` if the uniform algorithm is used, so `bayes_estimate.deduplicate_counts` should be ready for that situation when it's expanded to accept these totals as an argument (for computing the priors).

Also, "read" is replaced with "alignment" to be more consistent with pysam.
