### PR TITLE
UmiValues class

### DIFF
--- a/dedup.py
+++ b/dedup.py
@@ -37,7 +37,7 @@ try:
 except TypeError:
 	if args.algorithm == 'bayes':
 		umi_totals = umi_data.read_umi_counts_from_reads(in_bam, args.truncate_umi)
-		sys.stderr.write('%i\tusable alignments read\n\n' % sum(umi_totals.values()))
+		sys.stderr.write('%i\tusable alignments read\n\n' % sum(umi_totals.nonzero_values()))
 		in_bam.reset()
 	else:
 		umi_totals = None
@@ -46,7 +46,7 @@ except TypeError:
 prior = None
 if args.algorithm == 'bayes':
 	try:
-		denom = sum(umi_totals.values())
+		denom = sum(umi_totals.nonzero_values())
 		prior = collections.OrderedDict((umi, args.alpha * count / denom) for umi, count in umi_totals.iteritems())
 	except AttributeError:
 		args.algorithm = 'uniform-bayes'
@@ -71,7 +71,7 @@ out_bam.close()
 
 # report summary statistics
 if args.algorithm == 'bayes' and args.umi_table is None: # would already have reported alignments read
-	assert sum(umi_totals.values()) == dup_marker.counts['usable alignment']
+	assert sum(umi_totals.nonzero_values()) == dup_marker.counts['usable alignment']
 sys.stderr.write(
 	('%i\talignments read\n%i\tusable alignments read\n\n' % (dup_marker.counts['alignment'], dup_marker.counts['usable alignment']) if not (args.algorithm == 'bayes' and args.umi_table is None) else '') +
 	'%i\tdistinct alignments\n' % dup_marker.counts['distinct'] +

--- a/lib/markdup_sam.py
+++ b/lib/markdup_sam.py
@@ -123,9 +123,10 @@ class DuplicateMarker:
 					# second pass: mark PCR duplicates
 					alignments_by_umi = collections.defaultdict(list)
 					for this_alignment in alignments_to_dedup: alignments_by_umi[umi_data.get_umi(this_alignment.query_name, self.truncate_umi)] += [this_alignment]
-					dedup_counts = self.umi_dup_function(umi_data.make_umi_counts(alignments_by_umi.keys(), map(len, alignments_by_umi.values())))
-					for umi, alignments_with_this_umi, dedup_count in zip(alignments_by_umi.keys(), alignments_by_umi.values(), dedup_counts.values()):
-						assert alignments_with_this_umi
+					dedup_counts = self.umi_dup_function(umi_data.UmiValues([(umi, len(hits)) for umi, hits in alignments_by_umi.iteritems()]))
+					for umi, alignments_with_this_umi in alignments_by_umi.iteritems():
+						dedup_count = dedup_counts[umi]
+						assert alignments_with_this_umi and dedup_count
 						n_dup = len(alignments_with_this_umi) - dedup_count
 						for marked_alignment in umi_data.mark_duplicates(alignments_with_this_umi, n_dup):
 							alignment_categories[marked_alignment.query_name] = ('PCR duplicate' if marked_alignment.is_duplicate else 'nonduplicate')

--- a/lib/naive_estimate.py
+++ b/lib/naive_estimate.py
@@ -1,12 +1,13 @@
 from __future__ import division
+import umi_data
 
 def estimate_p (umi_counts):
-	n_hit = sum(umi_counts.values())
-	n_umi = sum(count > 0 for count in umi_counts.values())
+	n_hit, n_umi = 0
+	for count in umi_counts.nonzero_itervalues():
+		n_hit += count
+		n_umi += 1
 	return n_umi / n_hit
 
 def deduplicate_counts (umi_counts):
-	for key in umi_counts:
-		if umi_counts[key] > 0: umi_counts[key] = 1
-	return umi_counts
+	return umi_data.UmiValues([(key, 1) for key in umi_counts.nonzero_iterkeys()])
 

--- a/lib/umi_data.py
+++ b/lib/umi_data.py
@@ -1,35 +1,107 @@
 from __future__ import division
 import collections, itertools, re, pysam, parse_sam
 
-alphabet = 'ACGT' # expected characters in UMI sequences
-default_pair_separator = '+' # what separates the two UMIs in paired-end read names
-re_exclusion = re.compile('[^%s]' % (alphabet + default_pair_separator)) # match any unexpected character (like N)
+DEFAULT_ALPHABET = 'ACGT' # expected characters in UMI sequences
+DEFAULT_SEPARATOR = '+' # what separates the two UMIs in paired-end read names
+RE_EXCLUSION = re.compile('[^%s]' % (DEFAULT_ALPHABET + DEFAULT_SEPARATOR)) # match any unexpected character (like N)
 
 def umi_is_good (umi):
-	return (re_exclusion.search(umi) is None)
+	return (RE_EXCLUSION.search(umi) is None)
 
-def make_umi_list (length, separator_position = None, alphabet = alphabet):
+def get_separator_position (umi):
+	try:
+		return umi.index(DEFAULT_SEPARATOR)
+	except ValueError:
+		return None
+
+def make_umi_list (length, separator_position = None, alphabet = DEFAULT_ALPHABET):
 	for sequence in itertools.product(alphabet, repeat = length):
 		umi = ''.join(sequence)
-		if separator_position is not None: umi = umi[:separator_position] + default_pair_separator + umi[separator_position:]
+		if separator_position is not None: umi = umi[:separator_position] + DEFAULT_SEPARATOR + umi[separator_position:]
 		yield umi
+
+class UmiValues:
+	def __init__ (self,
+		initial_data = None, # should be list of (key, value) pairs
+		length = None,
+		separator_position = None,
+		alphabet = DEFAULT_ALPHABET
+	):
+		self.alphabet = alphabet
+		if initial_data is not None:
+			assert length is None and separator_position is None
+			example_umi = initial_data[0][0]
+			assert umi_is_good(example_umi)
+			self.length = len(example_umi) - example_umi.count(DEFAULT_SEPARATOR)
+			self.separator_position = get_separator_position(example_umi)
+			self.data = collections.Counter()
+			for pair in initial_data:
+				assert(self.is_valid(pair[0])) # verify valid entries
+				if pair[1] != 0: self.data[pair[0]] = pair[1]
+		else:
+			assert length is not None
+			self.length = length
+			self.separator_position = separator_position
+			self.data = collections.Counter()
+
+	def __len__ (self):
+		return len(self.alphabet) ** self.length
+	
+	def is_valid (self, key):
+		return (len(key) == self.length + (self.separator_position is not None) and get_separator_position(key) == self.separator_position)
+	
+	def __getitem__ (self, key):
+		if not self.is_valid(key): raise KeyError(key)
+		return self.data[key]
+	
+	def __setitem__ (self, key, value):
+		if not self.is_valid(key): raise KeyError(key)
+		if key == 0: # delete zeroes
+			try:
+				del self.data[key]
+			except KeyError:
+				pass
+		else:
+			self.data[key] = value
+
+	# standard dict functions	
+	def iterkeys (self):
+		return make_umi_list(self.length, self.separator_position, self.alphabet)
+	def keys (self):
+		return list(self.iterkeys())
+	def itervalues (self):
+		return (self.data[key] for key in self.iterkeys())
+	def values (self):
+		return list(self.itervalues())
+	def iteritems (self):
+		return ((key, self.data[key]) for key in self.iterkeys())
+	def items (self):
+		return list(self.iteritems())
+	
+	# special dict functions for nonzero values only
+	def nonzero_iterkeys (self):
+		return (key for key in sorted(self.data.keys()) if self.data[key]) # double check in case the Counter contains zeroes
+	def nonzero_keys (self):
+		return list(self.nonzero_iterkeys())
+	def nonzero_itervalues (self):
+		return (self.data[key] for key in self.nonzero_iterkeys())
+	def nonzero_values (self):
+		return list(self.nonzero_itervalues())
+	def nonzero_iteritems (self):
+		return ((key, self.data[key]) for key in self.nonzero_iterkeys())
+	def nonzero_items (self):
+		return list(self.nonzero_items())
 
 def get_umi (read_name, truncate = None):
 	for label in read_name.split(' ')[:2]: # to allow NCBI format or regular Illumina
 		if label.count(':') in (5, 7): # Casava pre-1.8: should be 5 (4 + the UMI hack); Casava 1.8+ / bcl2fastq 2.17+: should be 7 (with optional UMI field)
 			umi = label.partition('#')[0].partition('/')[0].rpartition(':')[2] # don't include the space or # and the stuff after it, if present
-			return (umi if truncate is None else umi[:truncate + umi.count(default_pair_separator)]) # don't count the pair separator when truncating
+			return (umi if truncate is None else umi[:truncate + umi.count(DEFAULT_SEPARATOR)]) # don't count the pair separator when truncating
 	# only get here if nothing was found
 	raise RuntimeError('read name %s does not contain UMI in expected Casava/bcl2fastq format' % label)
 
-def get_pair_separator_position (umi):
-	try:
-		return umi.index(default_pair_separator)
-	except ValueError:
-		return None
-
 def read_umi_counts_from_table (in_file, truncate = None):
-	result = collections.OrderedDict()
+	result = None
 	for line in in_file:
 		split_line = line.split()
 		try:
@@ -37,16 +109,15 @@ def read_umi_counts_from_table (in_file, truncate = None):
 			if truncate is not None: umi = umi[:truncate]
 			try:
 				result[umi] = int(split_line[1])
-			except IndexError: # no count given
-				result[umi] = 0
-		except IndexError: # empty line
+			except TypeError: # no result yet
+				result = UmiValues([(umi, 1)])
+		except IndexError: # insufficient data in this line
 			pass
 	if not result: raise RuntimeError('bad format in UMI table')
 	return result
 
 def read_umi_counts_from_reads (in_file, truncate = None): # in_file should be a pysam.Samfile or a Bio.SeqIO.parse in 'fastq' format, or at least contain an Illumina-formatted name in either 'query_name' or 'id'
-	umi_totals = collections.Counter()
-	umi_length = None
+	umi_totals = None
 	for read in in_file:
 		if hasattr(read, 'is_paired') and read.is_paired and not parse_sam.alignment_is_properly_paired(read): continue
 		try:
@@ -54,13 +125,11 @@ def read_umi_counts_from_reads (in_file, truncate = None): # in_file should be a
 		except AttributeError:
 			read_name = read.id # EAFP; if this isn't found either, AttributeError is still raised
 		umi = get_umi(read_name, truncate)
-		if len(umi) - umi.count(default_pair_separator) != umi_length:
-			if umi_length is None:
-				umi_length = len(umi) - umi.count(default_pair_separator)
-				umi_totals = make_umi_counts(make_umi_list(umi_length, get_pair_separator_position(umi)))
-			else:
-				raise RuntimeError('different UMI length in read ' + read_name)
-		umi_totals[umi] += 1
+		if not umi_is_good(umi): continue
+		try:
+			umi_totals[umi] += 1
+		except TypeError: # no data yet
+			umi_totals = UmiValues([(umi, 1)])
 	return umi_totals
 
 def mark_duplicates (reads, n):

--- a/make_frequency_table.py
+++ b/make_frequency_table.py
@@ -19,8 +19,7 @@ try: args.in_file.close()
 except AttributeError: pass # if it's a string it won't close, but that's okay because it's already garbage-collected
 
 # generate summary statistics
-sys.stderr.write('%i UMIs read\n' % sum(umi_totals.values()))
-for umi in umi_data.make_umi_list(len(umi_totals.keys()[0])):
-	args.out_file.write('%s\t%i\n' % (umi, umi_totals[umi]))
+sys.stderr.write('%i UMIs read\n' % sum(umi_totals.nonzero_itervalues()))
+for umi, count in umi_totals.iteritems():	args.out_file.write('%s\t%i\n' % (umi, count))
 args.out_file.close()
 


### PR DESCRIPTION
Added new UmiValues class and modified existing code to take advantage of it. It behaves similarly to a collections.OrderedDict, in that all the key-value pairs are ordered by UMI sequence, but it only uses memory for nonzero values (it wraps a collections.Counter), making it much more space-efficient when long UMIs are used. 

Notes:
- For best performance, use UmiValues.iterkeys rather than UmiValues.keys, UmiValues.itervalues rather than UmiValues.values, etc. where appropriate, since a full set of data is not stored in memory otherwise.
- Also, use the special nonzero versions of these members (UmiValues.nonzero_keys, UmiValues.nonzero_itervalues, etc.) for even bigger performance improvements when you don't need the zero values.
- A UmiValues object must be initialized either with a list of (key, value) pairs, in which case it infers the UMI configuration from the given examples, or with a "length" argument, in which case it starts with zeroes for all possible UMI sequences of that length.
- It's still a little crude and missing some basic members and documentation, but all the essentials seem to work.
