### PR TITLE
library stats; looks okay for single-end but not tested on paired-end

### DIFF
--- a/lib/library_stats.py
+++ b/lib/library_stats.py
@@ -1,0 +1,30 @@
+from __future__ import division
+import math
+
+EPSILON = 1e-9 # max error allowed for Newton's method
+
+def mean(x):
+	total = n = 0
+	for i in x:
+		total += i
+		n += 1
+	return total / n
+
+def entropy (x):
+	x_sum = sum(x)
+	p = (x_i / x_sum for x_i in x)
+	return - sum(p_i * math.log(p_i) for p_i in p if p_i != 0)
+
+def w0(x): # Lambert W function using Newton's method, http://code.activestate.com/recipes/577729-lambert-w-function/
+	w = x
+	while True:
+		ew = math.exp(w)
+		wNew = w - (w * ew - x) / (w * ew + ew)
+		if abs(w - wNew) <= EPSILON: break
+		w = wNew
+	return w
+
+def estimate_library_size(distinct_reads, total_reads): # from Lander-Waterman equation, http://sourceforge.net/p/samtools/mailman/samtools-help/thread/DUB405-EAS154589A1ACEF2BE4C573D4592180%40phx.gbl/#msg31513744
+	assert distinct_reads <= total_reads
+	return int(round((distinct_reads * total_reads) / (distinct_reads * w0(- math.exp(- total_reads / distinct_reads) * total_reads / distinct_reads) + total_reads)))
+


### PR DESCRIPTION
Adds library stat calculation (entropy statistics and estimated library size) to markdup_sam.DuplicateMarker: it now records the vector of UMI hit counts per position (each mate position separately), before and after deduplication, and includes methods to calculate the summary statistics from these. Since it may take a few seconds to calculate, it's disabled by default, and can be enabled with the '-s' flag.

With single-end reads this gives identical results to the previous library_stats branch, which contained the same library but wasn't implemented in a usable way because it was from before a major code overhaul. It hasn't been tested on paired-end reads yet...