### PR TITLE
Python 3 compatibility; still works in Python 2 but is slower now

### DIFF
--- a/dedup.py
+++ b/dedup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import copy, collections, argparse, pysam, sys
 from lib import parse_sam, umi_data, optical_duplicates, naive_estimate, bayes_estimate, markdup_sam, pysam_progress

--- a/extract_umi.py
+++ b/extract_umi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse, sys, collections
 from lib import parse_fastq

--- a/extract_umi_paired.py
+++ b/extract_umi_paired.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse, sys, collections
 from lib import parse_fastq

--- a/lib/bayes_estimate.py
+++ b/lib/bayes_estimate.py
@@ -11,8 +11,8 @@ DEFAULT_ALPHA1 = 1.5
 DEFAULT_ALPHA2 = 0.1
 
 def compute_prior (umi_counts):
-  denom = sum(umi_counts.nonzero_itervalues())
-  count_iter = umi_counts.nonzero_iteritems()
+  denom = sum(umi_counts.nonzero_values())
+  count_iter = umi_counts.nonzero_items()
   (first_umi, first_count) = next(count_iter)
   result = umi_data.UmiValues([(first_umi, first_count / denom)])
   for umi, count in count_iter: result[umi] = count / denom
@@ -23,23 +23,23 @@ def deduplicate_counts (umi_counts, nsamp=DEFAULT_NSAMP, nthin=DEFAULT_NTHIN, nb
 
     if filter_counts:
         # Remove zeros from data, to shorten the vector
-        data = umi_counts.nonzero_values()
-        umi_list = umi_counts.nonzero_iterkeys()
+        data = list(umi_counts.nonzero_values())
+        umi_list = umi_counts.nonzero_keys()
         if uniform:
             n = len(data)
             C_prior = [1./n] * n
         else:
-            C_prior = [prior[key] for key in umi_counts.nonzero_iterkeys()]
+            C_prior = [prior[key] for key in umi_counts.nonzero_keys()]
             n = len(data)
     else:
         data = umi_counts.values()
-        umi_list = umi_counts.iterkeys()
+        umi_list = umi_counts.keys()
         n = len(data)
 
     N = sum(data)
 
     # Set priors for the different parameters
-    k = len(umi_counts.nonzero_values())
+    k = len(list(umi_counts.nonzero_values()))
     pi_prior = [k * alpha2, (N - k) * alpha2]
     S_prior = [1.] * n
 
@@ -55,7 +55,7 @@ def deduplicate_counts (umi_counts, nsamp=DEFAULT_NSAMP, nthin=DEFAULT_NTHIN, nb
     data_dedup = apportion_counts(data, round(p * sum(data)))
 
     # Return UmiValues with estimated number of true molecules
-    umi_true = umi_data.UmiValues([(umi_counts.nonzero_keys()[0], 0)])
+    umi_true = umi_data.UmiValues([(list(umi_counts.nonzero_keys())[0], 0)])
     for umi, raw_count, dedup in zip(umi_list, data, data_dedup):
       if raw_count != 0:
         umi_true[umi] = int(round(dedup))

--- a/lib/kmeans.py
+++ b/lib/kmeans.py
@@ -1,10 +1,10 @@
-from itertools import imap, combinations
+from itertools import combinations
 import collections, operator
 
 def hamming(umi1, umi2):
         assert len(umi1) == len(umi2)
         ne = operator.ne
-        return sum(imap(ne, umi1, umi2))
+        return sum(map(ne, umi1, umi2))
 
 class DistanceMatrix:
     '''Create object that store distance matrices'''

--- a/lib/markdup_sam.py
+++ b/lib/markdup_sam.py
@@ -1,5 +1,4 @@
 import collections, copy
-from itertools import imap
 from . import parse_sam, umi_data, optical_duplicates, naive_estimate, bayes_estimate, sequence_error, library_stats
 
 # Initiate sequence correction functor
@@ -110,7 +109,7 @@ class DuplicateMarker:
 		if not pos_data.deduplicated:
 			this_pos_counts_by_mate_before = [] # tracker for summary statistics
 			this_pos_counts_by_mate_after = [] # tracker for summary statistics
-			for mate_start_pos, alignments_with_this_mate in pos_data.alignments_by_mate.iteritems(): # iterate over mate start positions
+			for mate_start_pos, alignments_with_this_mate in pos_data.alignments_by_mate.items(): # iterate over mate start positions
 				alignments_to_dedup = copy.copy(alignments_with_this_mate)
 
 				# if mate is already deduplicated, use those results
@@ -144,7 +143,7 @@ class DuplicateMarker:
 					alignment_categories = {} # key = alignment query_name, value = which category it is (from DUP_CATEGORIES or otherwise)
 					alignments_by_umi = collections.defaultdict(list)
 					for this_alignment in alignments_to_dedup: alignments_by_umi[umi_data.get_umi(this_alignment.query_name, self.truncate_umi)] += [this_alignment]
-					count_by_umi = umi_data.UmiValues([(umi, len(hits)) for umi, hits in alignments_by_umi.iteritems()])
+					count_by_umi = umi_data.UmiValues([(umi, len(hits)) for umi, hits in alignments_by_umi.items()])
 					self.pos_counts['before'].append(count_by_umi.nonzero_values())
 
 					# first pass: mark optical duplicates
@@ -164,7 +163,7 @@ class DuplicateMarker:
 					dedup_counts = self.umi_dup_function(count_by_umi)
 					self.pos_counts['after'].append(dedup_counts.nonzero_values())
 					if self.sequence_correction is not None:
-						pre_correction_count = sum(imap(len, alignments_by_umi.values()))
+						pre_correction_count = sum(map(len, alignments_by_umi.values()))
 						alignments_with_new_umi = self.sequence_correcter(alignments_by_umi)
 						try:
 							for alignment, umi in alignments_with_new_umi:
@@ -176,13 +175,13 @@ class DuplicateMarker:
 								    pass
 						except TypeError:
 							pass
-						post_correction_count = sum(imap(len, alignments_by_umi.values()))
+						post_correction_count = sum(map(len, alignments_by_umi.values()))
 						assert pre_correction_count == post_correction_count
 						# except AssertionError:
 						# 	print pre_correction_dict
-						# 	print {umi: len(hits) for umi, hits in alignments_by_umi.iteritems()}
+						# 	print {umi: len(hits) for umi, hits in alignments_by_umi.items()}
 						# 	print "\n* * * * *\n"
-					for umi, alignments_with_this_umi in alignments_by_umi.iteritems():
+					for umi, alignments_with_this_umi in alignments_by_umi.items():
 						dedup_count = dedup_counts[umi]
 						assert alignments_with_this_umi and dedup_count
 						n_dup = len(alignments_with_this_umi) - dedup_count
@@ -196,7 +195,7 @@ class DuplicateMarker:
 
 					# pass duplicate marking to mates
 					if mate_start_pos is not None:
-						for categorized_alignment, category in alignment_categories.iteritems():
+						for categorized_alignment, category in alignment_categories.items():
 							categorized_alignment_umi = umi_data.get_umi(categorized_alignment, self.truncate_umi)
 							self.pos_tracker[not alignment.is_reverse][mate_start_pos].alignments_already_processed[start_pos][categorized_alignment_umi][categorized_alignment] = category
 

--- a/lib/parse_fastq.py
+++ b/lib/parse_fastq.py
@@ -11,7 +11,7 @@ def get_umi (seq, length, before = 0, mask_pos = []):
 	
 	umi = str(seq[before:(before + length)])
 	if mask_pos is not None:
-		for pos, next_pos in itertools.izip_longest(mask_pos[::-1], mask_pos[-2::-1], fillvalue = None):
+		for pos, next_pos in itertools.zip_longest(mask_pos[::-1], mask_pos[-2::-1], fillvalue = None):
 			if next_pos >= pos: raise RuntimeError('mask_pos must be in ascending order')
 			umi = umi[:pos] + umi[pos + 1:]
 		

--- a/lib/sequence_error.py
+++ b/lib/sequence_error.py
@@ -1,4 +1,3 @@
-from itertools import imap
 import collections, operator
 from . import kmeans
 
@@ -88,7 +87,7 @@ class ClusterAndReducer:
     def _post_process_components_directional_(self, umis, components, adj_list, counts):
         # Make sure UMIs are assigned to only one cluster
         for umi in umis:
-            parent_clusters = filter(lambda x: (x & set([umi])) != set(), components)
+            parent_clusters = list(filter(lambda x: (x & set([umi])) != set(), components))
             if len(parent_clusters) > 1:
                 # Reassign to cluster whose representative has highest count
                 cluster_reps = [self.get_best(cluster, counts) for cluster in parent_clusters]

--- a/lib/umi_data.py
+++ b/lib/umi_data.py
@@ -66,32 +66,20 @@ class UmiValues:
 			self.data[key] = value
 
 	# standard dict functions
-	def iterkeys (self):
-		return make_umi_list(self.length, self.separator_position, self.alphabet)
 	def keys (self):
-		return list(self.iterkeys())
-	def itervalues (self):
-		return (self.data[key] for key in self.iterkeys())
+		return make_umi_list(self.length, self.separator_position, self.alphabet)
 	def values (self):
-		return list(self.itervalues())
-	def iteritems (self):
-		return ((key, self.data[key]) for key in self.iterkeys())
+		return (self.data[key] for key in self.keys())
 	def items (self):
-		return list(self.iteritems())
-
+		return ((key, self.data[key]) for key in self.keys())
+	
 	# special dict functions for nonzero values only
-	def nonzero_iterkeys (self):
-		return (key for key in sorted(self.data.keys()) if self.data[key]) # double check in case the Counter contains zeroes
 	def nonzero_keys (self):
-		return list(self.nonzero_iterkeys())
-	def nonzero_itervalues (self):
-		return (self.data[key] for key in self.nonzero_iterkeys())
+		return (key for key in sorted(self.data.keys()) if self.data[key]) # double check in case the Counter contains zeroes
 	def nonzero_values (self):
-		return list(self.nonzero_itervalues())
-	def nonzero_iteritems (self):
-		return ((key, self.data[key]) for key in self.nonzero_iterkeys())
+		return (self.data[key] for key in self.nonzero_keys())
 	def nonzero_items (self):
-		return list(self.nonzero_items())
+		return ((key, self.data[key]) for key in self.nonzero_keys())
 
 def get_umi (read_name, truncate = None):
 	for label in read_name.split(' ')[:2]: # to allow NCBI format or regular Illumina

--- a/make_frequency_table.py
+++ b/make_frequency_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import collections, itertools, argparse, sys, Bio.SeqIO, pysam
 from lib import umi_data
@@ -20,6 +20,6 @@ except AttributeError: pass # if it's a string it won't close, but that's okay b
 
 # generate summary statistics
 sys.stderr.write('%i UMIs read\n' % sum(umi_totals.nonzero_itervalues()))
-for umi, count in umi_totals.iteritems():	args.out_file.write('%s\t%i\n' % (umi, count))
+for umi, count in umi_totals.items():	args.out_file.write('%s\t%i\n' % (umi, count))
 args.out_file.close()
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 from distutils.core import setup, Extension
 from Cython.Build import cythonize
 from Cython.Distutils import build_ext


### PR DESCRIPTION
Well, that was easier than I expected.

Basically the only change is that in Python 3, the various separate "X" (return container) and "iterX" (return generator) functions have merged, so "X" always returns a generator, and if you really need a container, you have to populate one from the generator. Everything is slightly slower in Python 3 than it originally was in Python 2, unfortunately. However, now that the updated code is making unnecessary containers instead of generators if you run it in Python 2, it's also a little slower than it was before. So at least there's some parity.

Everything seems to run correctly but keep an eye out for bugs.