### PR TITLE
ignore soft-clipping and repair sequence correction

### DIFF
--- a/lib/markdup_sam.py
+++ b/lib/markdup_sam.py
@@ -142,14 +142,14 @@ class DuplicateMarker:
 						pre_correction_count = sum(map(len, alignments_by_umi.values()))
 						alignments_with_new_umi = self.sequence_correcter(alignments_by_umi)
 						try:
-							for alignment, umi in alignments_with_new_umi:
-								alignments_by_umi[umi].append(alignment)
+							for relabeled_alignment, umi in alignments_with_new_umi:
+								alignments_by_umi[umi].append(relabeled_alignment)
 								self.category_counts['sequence correction'] += 1
 								try:
-									  del alignments_by_umi[umi_data.get_umi(alignment)]
+									  del alignments_by_umi[umi_data.get_umi(relabeled_alignment)]
 								except KeyError:
 									  pass
-								umi_data.set_umi(alignment, umi)
+								umi_data.set_umi(relabeled_alignment, umi)
 						except TypeError:
 							pass
 						post_correction_count = sum(map(len, alignments_by_umi.values()))

--- a/lib/markdup_sam.py
+++ b/lib/markdup_sam.py
@@ -229,7 +229,7 @@ class DuplicateMarker:
 			# advance the buffer
 			while self.alignment_buffer and (
 				self.current_reference_id < alignment.reference_id or # new chromosome
-				parse_sam.get_start_pos(self.alignment_buffer[0]) < alignment.reference_start # oldest buffer member is now guaranteed not to get any more hits at its position
+				parse_sam.get_start_pos(self.alignment_buffer[0]) + parse_sam.MAX_READ_LENGTH < alignment.reference_start # oldest buffer member is now guaranteed not to get any more hits at its position (allow space in between for soft-clipped alignments with the same non-clipped start)
 			): yield self.pop_buffer()
 			if alignment.reference_id > self.current_reference_id: # clear the tracker
 				assert self.tracker_is_empty()

--- a/lib/markdup_sam.py
+++ b/lib/markdup_sam.py
@@ -142,14 +142,17 @@ class DuplicateMarker:
 						pre_correction_count = sum(map(len, alignments_by_umi.values()))
 						alignments_with_new_umi = self.sequence_correcter(alignments_by_umi)
 						try:
-							for relabeled_alignment, umi in alignments_with_new_umi:
-								alignments_by_umi[umi].append(relabeled_alignment)
+							for relabeled_alignment, new_umi in alignments_with_new_umi:
+								old_umi = umi_data.get_umi(relabeled_alignment)
+								alignments_by_umi[new_umi].append(relabeled_alignment)
+								count_by_umi[new_umi] += 1
+								count_by_umi[old_umi] -= 1
 								self.category_counts['sequence correction'] += 1
 								try:
-									  del alignments_by_umi[umi_data.get_umi(relabeled_alignment)]
+									  del alignments_by_umi[old_umi]
 								except KeyError:
 									  pass
-								umi_data.set_umi(relabeled_alignment, umi)
+								umi_data.set_umi(relabeled_alignment, new_umi)
 						except TypeError:
 							pass
 						post_correction_count = sum(map(len, alignments_by_umi.values()))

--- a/lib/parse_sam.py
+++ b/lib/parse_sam.py
@@ -1,5 +1,7 @@
 import collections, warnings, copy, pysam
 
+MAX_READ_LENGTH = 200 # maximum expected read length, to know when you're beyond soft-clipping range (set this high to be cautious)
+
 def alignment_is_good (alignment):
 	return not (alignment.is_unmapped or alignment.is_secondary or alignment.is_supplementary) # only count primary alignments, and discard unmapped reads since it's too expensive (and useless?) to find their duplicates
 
@@ -20,8 +22,8 @@ def alignment_is_properly_paired (alignment): # return True if pair is in expect
 		)
 	)
 
-def get_start_pos (alignment): # alignment start position in 0-based counting
-	return alignment.reference_end - 1 if alignment.is_reverse else alignment.reference_start
+def get_start_pos (alignment): # alignment start position in 0-based counting; do some arithmetic to ignore soft-clipping
+	return alignment.reference_end + (alignment.query_length - alignment.query_alignment_end) - 1 if alignment.is_reverse else alignment.reference_start - alignment.query_alignment_start
 
 def get_mate_start_pos (alignment): # paired alignment's start position in 0-based counting (returns None if unpaired)
 	if not alignment_is_properly_paired(alignment): return None

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.1'
+VERSION = '0.1.2'


### PR DESCRIPTION
Candidate duplicates were being identified by alignment start position, but this was separating obvious true duplicates that happened to be soft-clipped differently. Now soft-clipping is ignored.

Also, the sequence correction step had some bugs with integration into the pipeline, which are now fixed, though the `directional` algorithm still doesn't perform very well in saturated conditions.